### PR TITLE
remove compilation errors and unused dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,19 +2,20 @@ defmodule Poker.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :poker,
-     version: "0.0.2",
-     elixir: "~> 1.1",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps,
-     docs: fn ->
-       {ref, 0} = System.cmd("git", ["rev-parse", "--verify", "--quiet", "HEAD"])
-       [source_ref: ref, readme: "README.md", main: "Poker"]
-     end,
-     description: "An Elixir library to work with Poker hands.",
-     package: package,
-   ]
+    [
+      app: :poker,
+      version: "0.0.2",
+      elixir: "~> 1.1",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      docs: fn ->
+        {ref, 0} = System.cmd("git", ["rev-parse", "--verify", "--quiet", "HEAD"])
+        [source_ref: ref, readme: "README.md", main: "Poker"]
+      end,
+      description: "An Elixir library to work with Poker hands.",
+      package: package()
+    ]
   end
 
   # Configuration for the OTP application
@@ -35,8 +36,7 @@ defmodule Poker.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:markdown, github: "devinus/markdown", only: :dev},
-      {:ex_doc, "~> 0.11", only: :dev},
+      {:ex_doc, "~> 0.34", only: :dev}
     ]
   end
 
@@ -44,7 +44,7 @@ defmodule Poker.Mixfile do
     [
       licenses: ["MIT"],
       maintainers: ["Wojtek Mach"],
-      links: %{"GitHub" => "https://github.com/wojtekmach/poker_elixir"},
+      links: %{"GitHub" => "https://github.com/wojtekmach/poker_elixir"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,39 +1,27 @@
 defmodule Poker.Mixfile do
   use Mix.Project
 
+  @version "0.1.0"
+  @source_url "https://github.com/wojtekmach/poker_elixir"
+
   def project do
     [
       app: :poker,
-      version: "0.0.2",
+      version: @version,
       elixir: "~> 1.1",
-      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      docs: fn ->
-        {ref, 0} = System.cmd("git", ["rev-parse", "--verify", "--quiet", "HEAD"])
-        [source_ref: ref, readme: "README.md", main: "Poker"]
+      docs: [
+        source_url: @source_url,
+        source_ref: "v#{@version,
+        readme: "README.md",
+        main: "Poker"]
       end,
       description: "An Elixir library to work with Poker hands.",
       package: package()
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
-  def application do
-    [applications: [:logger]]
-  end
-
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:ex_doc, "~> 0.34", only: :dev}
@@ -44,7 +32,7 @@ defmodule Poker.Mixfile do
     [
       licenses: ["MIT"],
       maintainers: ["Wojtek Mach"],
-      links: %{"GitHub" => "https://github.com/wojtekmach/poker_elixir"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,11 @@
-%{"earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.11.2"},
+%{
+  "earmark": {:hex, :earmark, "0.1.19"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.41", "ab34711c9dc6212dda44fcd20ecb87ac3f3fce6f0ca2f28d4a00e4154f8cd599", [:mix], [], "hexpm", "a81a04c7e34b6617c2792e291b5a2e57ab316365c2644ddc553bb9ed863ebefa"},
+  "ex_doc": {:hex, :ex_doc, "0.34.2", "13eedf3844ccdce25cfd837b99bea9ad92c4e511233199440488d217c92571e8", [:mix], [{:earmark_parser, "~> 1.4.39", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_c, ">= 0.1.0", [hex: :makeup_c, repo: "hexpm", optional: true]}, {:makeup_elixir, "~> 0.14 or ~> 1.0", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1 or ~> 1.0", [hex: :makeup_erlang, repo: "hexpm", optional: false]}, {:makeup_html, ">= 0.1.0", [hex: :makeup_html, repo: "hexpm", optional: true]}], "hexpm", "5ce5f16b41208a50106afed3de6a2ed34f4acfd65715b82a0b84b49d995f95c1"},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
-  "markdown": {:git, "https://github.com/devinus/markdown.git", "9b3beaf69a9b9c6450526c41d591a94d2eedf1e8", []}}
+  "makeup": {:hex, :makeup, "1.1.2", "9ba8837913bdf757787e71c1581c21f9d2455f4dd04cfca785c70bbfff1a76a3", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cce1566b81fbcbd21eca8ffe808f33b221f9eee2cbc7a1706fc3da9ff18e6cac"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.16.2", "627e84b8e8bf22e60a2579dad15067c755531fea049ae26ef1020cad58fe9578", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b"},
+  "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
+  "markdown": {:git, "https://github.com/devinus/markdown.git", "9b3beaf69a9b9c6450526c41d591a94d2eedf1e8", []},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+}


### PR DESCRIPTION
I've been trying to use the version v0.02 and got some compilations errors due to the lack of parenthesis in the package and deps functions. Also, I've updated the ex_doc version and removed the markdown package that was causing compiling errors too due to the same reason. I didn't see any reference to the use of the package in the library, so I thought it was ok to remove it.